### PR TITLE
Updated to latest build tools and SDK and Android Studio 3.0.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
@@ -13,5 +14,6 @@ allprojects {
     repositories {
         mavenCentral()
         jcenter()
+        google()
     }
 }

--- a/busman/build.gradle
+++ b/busman/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 android {
-    compileSdkVersion 16
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.2"
 
     defaultConfig {
         applicationId "net.bbuzz.busman"
         minSdkVersion 14
-        targetSdkVersion 19
+        targetSdkVersion 27
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -23,7 +23,8 @@ android {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support.test:runner:0.4.1'
-    androidTestCompile 'com.android.support.test:rules:0.4.1'
-    compile 'com.android.support:support-annotations:23.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:support-annotations:27.0.2'
 }

--- a/busman/src/main/AndroidManifest.xml
+++ b/busman/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="27" />
 
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -36,6 +36,7 @@
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
+        android:theme="@style/AppTheme"
         android:label="@string/app_name" >
 
         <activity

--- a/busman/src/main/res/values/styles.xml
+++ b/busman/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- Base application theme. -->
+    <style name="AppTheme" parent="Theme.AppCompat">
+    </style>
+</resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 13 19:59:11 PDT 2017
+#Thu Jan 18 17:38:32 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Since API 24, the default theme is light, so we need to explicitly specify the dark theme now.